### PR TITLE
移除callbacks模組並更新開發路線圖

### DIFF
--- a/Instructor.md
+++ b/Instructor.md
@@ -5,6 +5,7 @@
 SBP_analyzer 是一個專注於 **Ad-hoc (離線) 模型訓練分析** 的工具包。它旨在協助開發者深入理解已完成的深度學習模型訓練過程。本工具包的核心功能是分析儲存在指定目錄結構中的訓練結果，包括模型架構、訓練指標、以及透過模型鉤子 (hooks) 擷取的中間層數據。
 
 本專案的目標是提供一個系統化、可擴展的框架，用以：
+
 - 解析和載入不同來源的訓練數據。
 - 計算多樣化的分析指標。
 - 提供豐富的視覺化工具以呈現分析結果。
@@ -99,71 +100,82 @@ layer_activation_dist = analysis_results.get_activation_distribution('patch_embe
 
 ## 3. 開發路線圖
 
-### 階段一：基礎架構和核心數據處理
+### 階段一：基礎架構和核心功能修復（已完成）
 
-1.  **建立核心架構**
-    *   實現 `analyzer`, `data_loader`, `metrics`, `visualization`, `reporter`, `utils`, `interfaces` 目錄結構。
-    *   定義 `BaseAnalyzer` 和 `BaseLoader` 抽象基礎類別。
-2.  **基礎數據載入**
-    *   實現 `ExperimentLoader` 以載入 MicDysphagiaFramework 格式的訓練結果 (config.json, training_history.json 等)。
-    *   實現 `HookDataLoader` 以載入 hook 目錄中的 .pt 數據文件。
-    *   實現 `file_utils` 來處理路徑和文件查找。
-3.  **基礎指標和視覺化**
-    *   實現 `distribution_metrics` 中的基本分布統計量。
-    *   實現 `performance_metrics` 中的基本訓練指標計算。
-    *   實現 `distribution_plots` 和 `performance_plots` 中的基礎繪圖功能 (e.g., 直方圖, 學習曲線)。
-4.  **建立測試基礎**
-    *   設置 `pytest` 環境。
-    *   建立 `test_data` 目錄並加入模擬數據。
-    *   為 `data_loader` 和 `utils` 編寫初步的單元測試。
+1. **[✅] 建立核心架構**
+   * 實現 `analyzer`, `data_loader`, `metrics`, `visualization`, `reporter`, `utils`, `interfaces` 目錄結構。
+   * 定義 `BaseAnalyzer` 和 `BaseLoader` 抽象基礎類別。
+2. **[✅] 基礎數據載入**
+   * 實現 `ExperimentLoader` 以載入標準格式的訓練結果。
+   * 實現 `file_utils` 來處理路徑和文件查找。
+3. **[✅] 核心功能修復**
+   * 修復 `stat_utils.py` 中的 `find_convergence_point` 和 `detect_outliers` 函數。
+   * 修正 `distribution_metrics.py` 中的 `calculate_histogram_intersection` 函數。
+   * 添加缺少的 `calculate_distribution_similarity` 和 `compare_tensor_distributions` 函數。
+   * 修改 `data_loader/experiment_loader.py` 中的 `load_model_structure` 方法，確保包含必要字段。
+4. **[✅] 建立測試基礎**
+   * 設置 `pytest` 環境。
+   * 創建 `run_tests.py` 腳本用於自動化測試。
+   * 為 `utils` 和 `metrics` 模組編寫基礎單元測試。
 
-### 階段二：核心分析功能開發
+### 階段二：分析功能增強（進行中）
 
-1.  **模型結構分析**
-    *   實現 `ModelStructureAnalyzer`，解析 model_structure.json 文件中的模型層次結構和參數信息。
-    *   實現 `model_structure_plots`，繪製模型層級圖和參數分布圖。
-2.  **訓練動態分析**
-    *   實現 `TrainingDynamicsAnalyzer`，分析 training_history.json 中的 Loss 和 Metrics 趨勢。
-    *   在 `performance_metrics` 中加入更進階的指標 (e.g., 移動平均、變異數)。
-    *   在 `performance_plots` 中加入更多視覺化選項 (e.g., 指標相關性圖)。
-3.  **報告生成器初步實現**
-    *   實現 `ReportGenerator`，能夠將文字、指標和圖像整合到一個簡單的 Markdown 或 HTML 報告中。
-4.  **擴充測試**
-    *   為 `analyzer`, `metrics`, `visualization` 模組增加單元測試。
+1. **模型結構分析完善**
+   * 擴展 `ModelStructureAnalyzer`，支持更多模型類型和架構解析。
+   * 增強模型參數統計分析功能，如稀疏度、權重分布等。
+   * 實現從 `model_structure.json` 到視覺化模型結構的轉換。
+2. **訓練動態分析強化**
+   * 完善 `performance_metrics.py` 中的分析函數，如 `analyze_loss_curve` 和 `analyze_metric_curve`。
+   * 增加學習效率和收斂性分析工具。
+   * 實現自動檢測訓練中的異常模式和瓶頸。
+3. **可視化功能基礎建設**
+   * 實現 `distribution_plots` 和 `performance_plots` 中的基礎繪圖功能。
+   * 建立統一的繪圖接口，支持多種圖表類型和樣式。
+4. **擴展單元測試**
+   * 為新增和修改的功能添加單元測試。
+   * 建立覆蓋全面的測試用例庫。
 
-### 階段三：中間層數據分析
+### 階段三：中間層數據分析與報告生成
 
-1.  **中間層數據分析器**
-    *   實現 `IntermediateDataAnalyzer`，分析 hooks 目錄中的激活值 (.pt) 數據。
-    *   實現 `layer_activity_metrics`，計算激活值的統計量 (e.g., 均值、標準差、稀疏度)。
-    *   實現 `layer_activity_plots`，繪製激活值的熱力圖或分布圖。
-2.  **進階分布比較**
-    *   在 `distribution_metrics` 中加入更複雜的指標 (e.g., KL 散度, Wasserstein 距離)。
-    *   在 `distribution_plots` 中加入比較視覺化 (e.g., 並排或重疊的分布圖)。
-3.  **增強報告功能**
-    *   允許自訂報告佈局和包含的內容。
-    *   支援輸出更多格式。
-4.  **整合測試**
-    *   編寫整合測試，模擬完整的分析流程。
+1. **中間數據加載與處理**
+   * 完成 `HookDataLoader` 以載入 hooks 目錄中的激活值數據。
+   * 實現張量數據的預處理和正規化功能。
+2. **層級活動分析**
+   * 實現 `layer_activity_metrics` 計算激活值的統計量和特徵。
+   * 設計層級行為分析算法，檢測異常激活模式。
+   * 實現層與層之間的相互關係分析。
+3. **報告生成器實現**
+   * 設計 `ReportGenerator`，整合分析結果到結構化報告。
+   * 支持多種報告格式（Markdown、HTML、PDF）。
+   * 建立報告模板系統，支持定制化報告內容。
+4. **整合測試與示例**
+   * 編寫端到端的整合測試案例。
+   * 創建示例數據集和分析流程演示。
 
-### 階段四：高級功能與易用性提升
+### 階段四：高級分析與生產環境準備
 
-1.  **交互式視覺化 (可選)**
-    *   探索整合 Plotly 或 Bokeh 等庫，提供交互式圖表。
-2.  **可配置性與擴展性**
-    *   允許用戶通過配置文件指定分析參數和要使用的模組。
-    *   設計易於擴展的接口，方便用戶添加自訂的分析器、載入器、指標或繪圖函數。
-3.  **文檔與示例**
-    *   完善 API 文檔和使用指南。
-    *   提供針對不同應用場景的詳細示例 (e.g., 分析 CNN 的特徵圖, 分析 Transformer 的注意力權重)。
-4.  **性能優化**
-    *   針對大型數據集和複雜分析進行性能評估和優化。
+1. **高級分析算法**
+   * 實現模型解釋性分析，如特徵重要性和敏感度分析。
+   * 設計模型比較系統，支持不同模型架構和超參數的對比。
+   * 開發訓練過程優化建議引擎。
+2. **交互式可視化**
+   * 集成 Plotly 或 Bokeh 等庫，提供交互式圖表。
+   * 實現自定義儀表板功能，支持用戶配置顯示內容。
+   * 開發基於網頁的結果瀏覽界面。
+3. **系統優化與性能提升**
+   * 優化大數據處理流程，支持分批處理和並行計算。
+   * 提升內存效率，處理超大規模模型和數據集。
+   * 實現結果緩存機制，提高重複分析效率。
+4. **文檔與部署**
+   * 完善 API 文檔和使用指南。
+   * 提供部署指南和生產環境配置最佳實踐。
+   * 創建示例和教程，覆蓋不同使用場景。
 
 ## 4. 數據載入器設計
 
 ### 4.1 MicDysphagiaFramework 實驗結果結構
 
-SBP_analyzer 主要針對 MicDysphagiaFramework 產生的實驗結果進行分析。以下是預期的輸入目錄結構和文件格式：
+SBP_analyzer 主要針對 MicDysphagiaFramework （/SBP_analyzer/results）產生的實驗結果進行分析。以下是預期的輸入目錄結構和文件格式：
 
 ```
 results/
@@ -200,22 +212,22 @@ results/
 class ExperimentLoader:
     def __init__(self, experiment_dir):
         self.experiment_dir = experiment_dir
-    
+  
     def load_config(self):
         """載入 config.json 中的實驗配置"""
         with open(os.path.join(self.experiment_dir, 'config.json'), 'r') as f:
             return json.load(f)
-    
+  
     def load_model_structure(self):
         """載入 model_structure.json 中的模型結構信息"""
         with open(os.path.join(self.experiment_dir, 'model_structure.json'), 'r') as f:
             return json.load(f)
-    
+  
     def load_training_history(self):
         """載入 training_history.json 中的訓練歷史記錄"""
         with open(os.path.join(self.experiment_dir, 'training_history.json'), 'r') as f:
             return json.load(f)
-    
+  
     def load_results(self):
         """載入 results/results.json 中的最終結果摘要"""
         results_path = os.path.join(self.experiment_dir, 'results', 'results.json')
@@ -234,23 +246,23 @@ class HookDataLoader:
     def __init__(self, experiment_dir):
         self.experiment_dir = experiment_dir
         self.hooks_dir = os.path.join(experiment_dir, 'hooks')
-    
+  
     def load_training_summary(self):
         """載入整體訓練摘要"""
         return torch.load(os.path.join(self.hooks_dir, 'training_summary.pt'))
-    
+  
     def load_evaluation_results(self, dataset='test'):
         """載入評估結果"""
         return torch.load(os.path.join(self.hooks_dir, f'evaluation_results_{dataset}.pt'))
-    
+  
     def load_epoch_summary(self, epoch):
         """載入特定輪次的摘要"""
         return torch.load(os.path.join(self.hooks_dir, f'epoch_{epoch}', 'epoch_summary.pt'))
-    
+  
     def load_batch_data(self, epoch, batch):
         """載入特定批次的數據"""
         return torch.load(os.path.join(self.hooks_dir, f'epoch_{epoch}', f'batch_{batch}_data.pt'))
-    
+  
     def load_layer_activation(self, layer_name, epoch, batch):
         """載入特定層在特定批次的激活值"""
         pattern = f"{layer_name}_activation_batch_{batch}.pt"
@@ -258,12 +270,12 @@ class HookDataLoader:
         if os.path.exists(path):
             return torch.load(path)
         return None
-    
+  
     def list_available_epochs(self):
         """列出可用的輪次"""
         return [int(d.split('_')[1]) for d in os.listdir(self.hooks_dir) 
                 if d.startswith('epoch_') and os.path.isdir(os.path.join(self.hooks_dir, d))]
-    
+  
     def list_available_layer_activations(self, epoch):
         """列出特定輪次中可用的層激活值文件"""
         epoch_dir = os.path.join(self.hooks_dir, f'epoch_{epoch}')
@@ -289,9 +301,9 @@ pip install -e .
 
 ### 5.2 測試環境
 
--   **測試框架**: 使用 `pytest`。
--   **測試數據**: 在 `tests/test_data/` 目錄下創建模擬的實驗結果目錄結構和數據文件，參照 MicDysphagiaFramework 的輸出格式。
--   **測試覆蓋率**: 目標是保持主要模組的測試覆蓋率在 80% 以上。
+- **測試框架**: 使用 `pytest`。
+- **測試數據**: 在 `tests/test_data/` 目錄下創建模擬的實驗結果目錄結構和數據文件，參照 MicDysphagiaFramework 的輸出格式。
+- **測試覆蓋率**: 目標是保持主要模組的測試覆蓋率在 80% 以上。
 
 ```python
 # tests/test_data_loader.py 範例
@@ -316,50 +328,54 @@ def test_hook_data_loader_loads_training_summary(mock_experiment_dir):
 
 ### 6.1 數據處理與記憶體
 
-1.  **延遲載入 (Lazy Loading)**: 對於大型的 hook 數據，僅在實際需要分析時才載入記憶體。
-2.  **抽樣 (Sampling)**: 對於大型激活值張量，提供抽樣選項以加速分析和視覺化。
-3.  **數據格式**: 內部盡量使用高效的數據結構 (如 Pandas DataFrame, NumPy arrays, PyTorch Tensors)。
+1. **延遲載入 (Lazy Loading)**: 對於大型的 hook 數據，僅在實際需要分析時才載入記憶體。
+2. **抽樣 (Sampling)**: 對於大型激活值張量，提供抽樣選項以加速分析和視覺化。
+3. **數據格式**: 內部盡量使用高效的數據結構 (如 Pandas DataFrame, NumPy arrays, PyTorch Tensors)。
 
 ### 6.2 模組化與可配置性
 
-1.  **解耦**: 分析器、載入器、指標計算、視覺化應盡量解耦，方便獨立測試和替換。
-2.  **配置**: 允許用戶通過接口參數或配置文件來自訂分析流程，例如選擇要運行的分析器、要計算的指標、要生成的圖表等。
+1. **解耦**: 分析器、載入器、指標計算、視覺化應盡量解耦，方便獨立測試和替換。
+2. **配置**: 允許用戶通過接口參數或配置文件來自訂分析流程，例如選擇要運行的分析器、要計算的指標、要生成的圖表等。
 
 ### 6.3 錯誤處理與日誌
 
-1.  **健壯性**: `DataLoader` 應能處理文件缺失或格式錯誤的情況，並提供有意義的錯誤訊息。
-2.  **日誌**: 在分析過程中記錄詳細的日誌，包括載入了哪些數據、執行了哪些分析、遇到的警告或錯誤等。
+1. **健壯性**: `DataLoader` 應能處理文件缺失或格式錯誤的情況，並提供有意義的錯誤訊息。
+2. **日誌**: 在分析過程中記錄詳細的日誌，包括載入了哪些數據、執行了哪些分析、遇到的警告或錯誤等。
 
 ## 7. 開發指南
 
 ### 7.1 編碼規範
 
-1.  遵循 PEP 8 風格指南。
-2.  為所有公共方法、類和模組提供清晰的 Docstrings (遵循如 Google 或 NumPy 風格)。
-3.  使用類型註解 (Type Hinting) 增強代碼可讀性和可靠性。
+1. 遵循 PEP 8 風格指南。
+2. 為所有公共方法、類和模組提供清晰的 Docstrings (遵循如 Google 或 NumPy 風格)。
+3. 使用類型註解 (Type Hinting) 增強代碼可讀性和可靠性。
 
 ### 7.2 測試規範
 
-1.  為每個新功能或錯誤修復編寫單元測試。
-2.  確保測試涵蓋邊界條件和預期的錯誤情況。
-3.  定期運行測試套件並檢查覆蓋率報告。
+1. 為每個新功能或錯誤修復編寫單元測試。
+2. 確保測試涵蓋邊界條件和預期的錯誤情況。
+3. 定期運行測試套件並檢查覆蓋率報告。
 
 ### 7.3 提交規範
 
-1.  遵循 Conventional Commits 規範或其他清晰的提交訊息格式。
-2.  每個提交應專注於一個邏輯單元 (如一個功能、一個修復)。
-3.  保持 Git 歷史清晰。
+1. 遵循 Conventional Commits 規範或其他清晰的提交訊息格式。
+2. 每個提交應專注於一個邏輯單元 (如一個功能、一個修復)。
+3. 保持 Git 歷史清晰。
 
 ## 8. 常見問題解答 (預期)
 
 ### Q: `SBP_analyzer` 是否支持非 MicDysphagiaFramework 產生的實驗結果？
+
 A: 初期會專注於支持 MicDysphagiaFramework 的輸出格式。未來計劃添加適配器，以支持其他框架 (如 PyTorch Lightning, TensorFlow) 的輸出格式。
 
 ### Q: 如何處理非常大的激活值數據文件？
+
 A: `HookDataLoader` 提供選項來僅載入數據的子集或進行抽樣。同時，分析器和視覺化模組也設計為能夠處理抽樣後的數據。
 
 ### Q: 我可以添加自己的分析指標或視覺化方法嗎？
+
 A: 是的，設計目標之一就是提供可擴展的接口。用戶應該能夠繼承基礎類別 (如 `BaseAnalyzer`, `BaseMetricCalculator`, `BasePlotter`) 並註冊自己的實現。
 
 ### Q: 分析報告可以自訂嗎？
+
 A: `ReportGenerator` 將提供選項來自訂報告中包含的內容、順序和可能的格式。


### PR DESCRIPTION
## 變更說明

本PR旨在更新SBP_analyzer的開發路線圖，並明確callback模組的處理方式。由於本專案專注於Ad-hoc（離線）分析，與即時監控不同，舊有的callbacks模組不再適用於此架構。

### 主要變更：

1. 更新了`Instructor.md`中的開發路線圖，反映當前的開發進度：
   - 將階段一標記為已完成，包括核心架構建立和基礎功能修復
   - 更新階段二至階段四的任務內容，使其更加具體和符合專案方向
   - 移除了對即時監控相關功能的描述

2. 確認了不需要重建舊有的callbacks模組，因為：
   - SBP_analyzer專注於離線分析，不參與訓練過程的即時監控
   - 舊有callbacks是為即時監控而設計，與目前Ad-hoc分析的架構不符
   - 相關功能已被資料載入器（data_loader）和分析器（analyzer）模組取代

### 技術細節：

- 在Ad-hoc分析模式下，系統直接從results目錄讀取訓練完成後的資料
- 原本由callbacks收集的資料現在通過data_loader模組載入
- 原本由callbacks執行的分析現在由各種專用analyzer模組處理

## 相關問題

此PR解決了對callback模組處理方式的疑問，確認當前架構下不需要重建callback模組。